### PR TITLE
Add custom landing page layout with recent post and sidebar

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,39 @@
+{{ define "content" }}
+<section class="container">
+  <div style="display: flex; gap: 2rem;">
+    <!-- Left 2/3: Most Recent Post -->
+    <div style="flex: 2;">
+      {{ $recent := first 1 (where site.RegularPages "Type" "posts") }}
+      {{ range $recent }}
+        <article>
+          <header>
+            <h1><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
+            <time>{{ .Date.Format "January 2, 2006" }}</time>
+          </header>
+          <div>
+            {{ .Content | truncate 500 }}
+          </div>
+          <footer>
+            <a href="{{ .Permalink }}">Read more →</a>
+          </footer>
+        </article>
+      {{ end }}
+    </div>
+    
+    <!-- Right 1/3: Post List -->
+    <div style="flex: 1; border-left: 1px solid #ccc; padding-left: 2rem;">
+      <h2>Recent Posts</h2>
+      <ul style="list-style: none; padding: 0;">
+        {{ range first 10 (where site.RegularPages "Type" "posts") }}
+          <li style="margin-bottom: 1rem; padding-bottom: 0.5rem; border-bottom: 1px solid #eee;">
+            <a href="{{ .Permalink }}" style="text-decoration: none;">
+              <div style="font-weight: bold;">{{ .Title }}</div>
+              <div style="font-size: 0.9em; color: #666;">{{ .Date.Format "Jan 2, 2006" }}</div>
+            </a>
+          </li>
+        {{ end }}
+      </ul>
+    </div>
+  </div>
+</section>
+{{ end }}


### PR DESCRIPTION
- Create layouts/index.html to override theme default
- Display most recent post content on left 2/3 of page
- Show list of recent posts on right 1/3 sidebar
- Use flexbox layout for responsive design

🤖 Generated with [Claude Code](https://claude.ai/code)